### PR TITLE
Update to required Regexp syntax for ruby 3.3.0.

### DIFF
--- a/cookiejar.gemspec
+++ b/cookiejar.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.rdoc_options  = ['--title', 'CookieJar -- Client-side HTTP Cookies']
   s.require_paths = ['lib']
 
-  s.add_development_dependency 'rake', '>= 10.0', '< 13'
+  s.add_development_dependency 'rake', '>= 10.0'
   s.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'yard',  '~> 0.9.20'

--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -45,7 +45,7 @@ module CookieJar
     HDN = /\A#{PATTERN::HOSTNAME}\Z/
     TOKEN = /\A#{PATTERN::TOKEN}\Z/
     PARAM1 = /\A(#{PATTERN::TOKEN})(?:=#{PATTERN::VALUE1})?\Z/
-    PARAM2 = Regexp.new "(#{PATTERN::TOKEN})(?:=(#{PATTERN::VALUE2}))?(?:\\Z|;)", '', 'n'
+    PARAM2 = Regexp.new("(#{PATTERN::TOKEN})(?:=(#{PATTERN::VALUE2}))?(?:\\Z|;)", Regexp::NOENCODING)
     # TWO_DOT_DOMAINS = /\A\.(com|edu|net|mil|gov|int|org)\Z/
 
     # Converts the input object to a URI (if not already a URI)

--- a/lib/cookiejar/version.rb
+++ b/lib/cookiejar/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module CookieJar
-  VERSION = '0.3.3'.freeze
+  VERSION = '0.3.4'.freeze
 end

--- a/spec/cookie_spec.rb
+++ b/spec/cookie_spec.rb
@@ -65,10 +65,10 @@ describe Cookie do
       expect(cookie.secure).to be_truthy
     end
     it 'should fail on unquoted paths' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie2 'https://www.google.com/a/blah',
                                 'GALX=RgmSftjnbPM;Path=/a/;Secure;Version=1'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should accept quoted values' do
       cookie = Cookie.from_set_cookie2 'http://localhost/', 'foo="bar";Version=1'

--- a/spec/cookie_validation_spec.rb
+++ b/spec/cookie_validation_spec.rb
@@ -5,46 +5,46 @@ describe CookieValidation do
   describe '#validate_cookie' do
     localaddr = 'http://localhost/foo/bar/'
     it 'should fail if version unset' do
-      expect(lambda do
+      expect {
         unversioned = Cookie.from_set_cookie localaddr, 'foo=bar'
         unversioned.instance_variable_set :@version, nil
         CookieValidation.validate_cookie localaddr, unversioned
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail if the path is more specific' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie localaddr, 'foo=bar;path=/foo/bar/baz'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail if the path is different than the request' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie localaddr, 'foo=bar;path=/baz/'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail if the domain has no dots' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://zero/', 'foo=bar;domain=zero'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for explicit localhost' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie localaddr, 'foo=bar;domain=localhost'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for mismatched domains' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://www.foo.com/', 'foo=bar;domain=bar.com'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for domains more than one level up' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://x.y.z.com/', 'foo=bar;domain=z.com'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should fail for setting subdomain cookies' do
-      expect(lambda do
+      expect {
         Cookie.from_set_cookie 'http://foo.com/', 'foo=bar;domain=auth.foo.com'
-      end).to raise_error InvalidCookieError
+      }.to raise_error InvalidCookieError
     end
     it 'should handle a normal implicit internet cookie' do
       normal = Cookie.from_set_cookie 'http://foo.com/', 'foo=bar'


### PR DESCRIPTION
Also correct deprecation warnings in specs.

Published as 0.3.4